### PR TITLE
Added mac ADB installation and possible error fix

### DIFF
--- a/Auto_2.ps1
+++ b/Auto_2.ps1
@@ -1,3 +1,3 @@
 if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) { Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`"" -Verb RunAs; exit }
 choco install visualstudio2019-workload-vctools -y
-PowerShell -NoExit "C:\"
+$null = host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")

--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ Join our [Discord Channel](https://discord.gg/HZXCzDXXJJ)
 ```
 brew install tesseract (install homebrew if you have not)
 ```
+3. Install ADB
+```
+brew cask install android-platform-tools
+```
+4. Connect your device to your mac and run the following to see if it can detect your device
+```
+adb devices
+```
 
 ### Linux
 1. Install tesseract via apt by using the command


### PR DESCRIPTION
With the changes made the error 
```
C:\ : The term 'C:' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the
spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:1
+ C:\
+ ~~~
    + CategoryInfo          : ObjectNotFound: (C::String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```
will be fixed(Most probably)